### PR TITLE
Fix misplaced closing bracket

### DIFF
--- a/Competency-Frameworks/ConnectingCredentials.json
+++ b/Competency-Frameworks/ConnectingCredentials.json
@@ -282,7 +282,7 @@
     {
       "@id": "https://credentialengineregistry.org/resources/ce-0d9b392f-91cd-4a95-8c07-4f3f1a785e9b",
       "@type": "ceasn:Competency",
-      "ceasn:CompetencyCategory": {"en-US": "Competency",
+      "ceasn:CompetencyCategory": {"en-US": "Competency"},
       "ceasn:competencyText": {"en-US": "Demonstrates advanced interpersonal abilities required in learning and in the workplace, including the ability to present complex facts and circumstances and to communicate about solutions in a manner that is contextually appropriate to cross-disciplinary audiences."},
       "ceasn:complexityLevel": "https://credentialengineregistry.org/resources/ce-e58703f7-15f3-44cd-a039-509896c0ec6e",
       "ceasn:inLanguage": "http://id.loc.gov/vocabulary/iso639-2/eng",
@@ -290,7 +290,6 @@
       "ceasn:isPartOf": "https://credentialengineregistry.org/resources/ce-c62c336f-a76d-4d7f-a777-367e7cc72d17",
       "ceterms:ctid": "ce-0d9b392f-91cd-4a95-8c07-4f3f1a785e9b",
       "ceasn:shouldIndex": "true"
-      }
     },
     {
       "@id": "https://credentialengineregistry.org/resources/ce-6f07f75b-74aa-4334-a92b-2f103f115bd2",


### PR DESCRIPTION
A typo in the Connecting Credentials framework was causing problems on import into the CaSS Editor.